### PR TITLE
Enable nats server monitoring in frontend-react

### DIFF
--- a/frontend-react/.nats.conf
+++ b/frontend-react/.nats.conf
@@ -3,6 +3,8 @@ authorization: {
     password: nats,
 }
 
+http_port: 8222
+
 websocket: {
      port: 9222
      no_tls: true


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

We forward the monitoring port `127.0.0.1:8222:8222` in the `frontend-react/docker-compose.yml` but we don't enable it in the server config. This PR fixes this.

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

_none_

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
