### PR TITLE
Disallow widgets to resize based on their content

### DIFF
--- a/frontend-react/src/lib/widget/component/widget-renderer.module.css
+++ b/frontend-react/src/lib/widget/component/widget-renderer.module.css
@@ -1,4 +1,10 @@
 .widgetRenderer {
+	/* Initial state, gets overwritten through inline styles */
 	--id: loading;
+
+	/* Place the widget in the correct grid area */
 	grid-area: var(--id);
+
+	/* Disallow grid areas to resize based on content */
+	overflow: auto;
 }


### PR DESCRIPTION
Previously, widget sizes would vary baased on the content.

Cf. https://www.w3.org/TR/css3-grid-layout/#min-size-auto – by adding `overflow: auto` to the widget containers, they become scroll containers (the grid items) and their _"automatic minimum size is zero, as usual"_.

Thanks to https://stackoverflow.com/a/43312314/9276604 for the hint!
