### PR TITLE
Restore login session upon reload

### DIFF
--- a/frontend-react/src/lib/application/routes/dashboard-editor/routing.ts
+++ b/frontend-react/src/lib/application/routes/dashboard-editor/routing.ts
@@ -20,7 +20,7 @@ export function dashboardEditorLoader({ version }: TelestionOptions) {
 		if (!isLoggedIn()) {
 			if (params.dashboardId) {
 				setResumeAfterLogin(
-					generatePath('/dashboards/:dashboardId', {
+					generatePath('/dashboards/:dashboardId/edit', {
 						dashboardId: params.dashboardId
 					})
 				);

--- a/frontend-react/src/lib/application/routes/login/routing.ts
+++ b/frontend-react/src/lib/application/routes/login/routing.ts
@@ -1,5 +1,5 @@
 import { ActionFunctionArgs, redirect } from 'react-router-dom';
-import { isLoggedIn, login, LoginError } from '../../../auth';
+import { attemptAutoLogin, isLoggedIn, login, LoginError } from '../../../auth';
 import { TelestionOptions } from '../../model.ts';
 import { wait } from '../../../utils.ts';
 
@@ -21,11 +21,15 @@ export function resetResumeAfterLogin() {
 }
 
 export function loginLoader({ defaultBackendUrl }: TelestionOptions) {
-	return () => {
+	return async () => {
 		if (isLoggedIn()) {
 			return redirect('/');
 		}
 
+		// try to log in with the credentials from the session storage
+		if (await attemptAutoLogin()) return redirect(resumeAfterLogin ?? '/');
+
+		// show the login form
 		return {
 			defaultBackendUrl
 		};

--- a/frontend-react/src/lib/auth/auto-login.ts
+++ b/frontend-react/src/lib/auth/auto-login.ts
@@ -1,0 +1,99 @@
+import { login } from './controller.ts';
+import { z } from 'zod';
+
+const AUTO_LOGIN_KEY = 'auto-login';
+
+const autoLoginSchema = z.object({
+	natsUrl: z.string(),
+	username: z.string(),
+	password: z.string()
+});
+
+/**
+ * Attempt to auto-login using credentials stored in sessionStorage.
+ *
+ * The credentials will automatically be cleared if they are invalid, the
+ * session ends, or {@link logout} is called.
+ *
+ * Credentials are automatically stored updated by {@link login} and
+ * {@link logout}.
+ *
+ * @returns true if auto-login was successful, false otherwise
+ */
+export async function attemptAutoLogin(): Promise<boolean> {
+	console.log('Attempting auto-login');
+	const autoLogin = window.sessionStorage.getItem(AUTO_LOGIN_KEY);
+
+	if (!autoLogin) {
+		// This is perfectly normal, so don't log a warning, just return false
+		return false;
+	}
+
+	const parsedAutoLoginData = autoLoginSchema.safeParse(
+		JSON.parse(decrypt(autoLogin))
+	);
+
+	if (!parsedAutoLoginData.success) {
+		console.warn('Invalid auto-login credentials type');
+		return false;
+	}
+
+	const { natsUrl, username, password } = parsedAutoLoginData.data;
+
+	try {
+		await login(natsUrl, username, password);
+		return true;
+	} catch (err) {
+		console.warn('Auto-login failed:', err);
+		clearAutoLogin(); // credentials didn't work, so discard them
+		return false;
+	}
+}
+
+/**
+ * @internal
+ * Store auto-login credentials in sessionStorage.
+ *
+ * @param credentials - The credentials to store
+ */
+export function setAutoLoginCredentials(
+	credentials: z.input<typeof autoLoginSchema>
+) {
+	window.sessionStorage.setItem(
+		AUTO_LOGIN_KEY,
+		encrypt(JSON.stringify(autoLoginSchema.parse(credentials)))
+	);
+}
+
+/**
+ * @internal
+ * Clear auto-login credentials from sessionStorage.
+ */
+export function clearAutoLogin() {
+	console.log('Clearing auto-login credentials');
+	window.sessionStorage.removeItem(AUTO_LOGIN_KEY);
+}
+
+/**
+ * @internal
+ * Encrypt a string to obfuscate it in sessionStorage.
+ * @param str - The string to encrypt
+ * @returns The encrypted string
+ *
+ * @see decrypt
+ */
+function encrypt(str?: string) {
+	return btoa(str ?? 'null');
+}
+
+/**
+ * @internal
+ * Decrypt a string that was obfuscated in sessionStorage.
+ * @param str - The string to decrypt
+ * @returns The decrypted string
+ *
+ * @see encrypt
+ */
+function decrypt(str?: string) {
+	return atob(str ?? 'null');
+}

--- a/frontend-react/src/lib/auth/controller.ts
+++ b/frontend-react/src/lib/auth/controller.ts
@@ -7,6 +7,7 @@ import {
 import { LoginError, ErrorMessages } from './model.ts';
 import { connect, NatsError } from 'nats.ws';
 import { z } from 'zod';
+import { clearAutoLogin, setAutoLoginCredentials } from './auto-login.ts';
 
 const natsUrlSchema = z.string().url();
 const credentialsSchema = z.string().min(1).max(800);
@@ -81,6 +82,12 @@ export async function login(
 		setUser({ natsUrl, username });
 		setNatsConnection(nc);
 
+		setAutoLoginCredentials({
+			natsUrl,
+			username,
+			password: password
+		});
+
 		console.log('Successfully logged in');
 		return getUser();
 	} catch (err) {
@@ -100,6 +107,8 @@ export async function login(
  * @returns A promise that resolves once the user is logged out.
  */
 export async function logout() {
+	clearAutoLogin();
+
 	if (!isLoggedIn()) {
 		console.log('Already logged out');
 		return;

--- a/frontend-react/src/lib/auth/index.ts
+++ b/frontend-react/src/lib/auth/index.ts
@@ -1,4 +1,5 @@
 export * from './model.ts';
 export * from './state.ts';
 export * from './controller.ts';
+export { attemptAutoLogin } from './auto-login.ts';
 export * from './hooks';


### PR DESCRIPTION
With this change, credentials get stored in the `sessionStorage` in an obfuscated way upon login.

When the login route gets loaded, the application trys to automatically sign in using any stored credentials.

Credentials (and thus, the login session) are automatically once either:

1. the tab/browser gets closed (cf. https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage), or
2. the `logout()` function gets called (e.g., when the user logs out manually), or
3. a login attempt with the stored credentials fails.

This significantly improves the user experience since refreshing pages works without any issues, now.

Also, the developer experience is significantly improved as developers no longer need to sign back in everytime a reload happens during development.
