### PR TITLE
TELESTION-450: Re-export NATS for convenience

### DIFF
--- a/frontend-react/src/lib/index.ts
+++ b/frontend-react/src/lib/index.ts
@@ -27,6 +27,7 @@ export * as auth from './auth';
 export * as userData from './user-data';
 export * as widget from './widget';
 export * as utils from './utils.ts';
+export * as nats from './nats';
 
 // application
 export { initTelestion, useWidgetConfig } from './application';
@@ -41,3 +42,6 @@ export type { UserData } from './user-data';
 
 // auth
 export { useNats } from './auth';
+
+// nats
+export { JSONCodec } from './nats';

--- a/frontend-react/src/lib/nats/index.ts
+++ b/frontend-react/src/lib/nats/index.ts
@@ -1,0 +1,16 @@
+// re-export NATS utils (for convenience)
+export { JSONCodec, StringCodec, headers } from 'nats.ws';
+export type {
+	NatsError,
+	NatsConnection,
+	Codec,
+	Msg,
+	MsgHdrs,
+	Sub,
+	SubOpts,
+	Subscription,
+	SubscriptionOptions,
+	MsgRequest,
+	RequestOptions,
+	PublishOptions
+} from 'nats.ws';


### PR DESCRIPTION
Exposes various NATS types directly from the `@wuespace/telestion` package itself for convenience.

Most things are exported under the `nats` namespace, while selected variables and/or types are even exposed in the global package's scope.
