### PR TITLE
Improve the name for new dashboards

### DIFF
--- a/frontend-react/src/lib/user-data/model.ts
+++ b/frontend-react/src/lib/user-data/model.ts
@@ -108,7 +108,7 @@ export function getEmptyDashboard(): readonly [
 	return [
 		id,
 		{
-			title: 'Empty Dashboard',
+			title: `Untitled (${new Date().toLocaleString()})`,
 			layout: [
 				['.', '.'],
 				['.', '.']


### PR DESCRIPTION
Previously, all freshly created dashboards had the exact same name. We now include the current date and time upon creation.