### PR TITLE
TELESTION-473 Use `DATA_DIR` in logger sample

### DIFF
--- a/backend-deno/samples/logger/mod.ts
+++ b/backend-deno/samples/logger/mod.ts
@@ -1,9 +1,13 @@
 import { startService } from "https://deno.land/x/telestion/mod.ts";
 import { encode } from "https://deno.land/std@0.186.0/encoding/hex.ts";
+import { resolve } from "https://deno.land/std@0.186.0/path/mod.ts";
 
 const encoder = new TextEncoder();
 
-const { messageBus } = await startService();
+const { messageBus, dataDir } = await startService();
+
+const logFilePath = resolve(dataDir, "log.txt");
+await Deno.mkdir(dataDir, { recursive: true });
 
 const logMessages = messageBus.subscribe("log.>");
 
@@ -17,7 +21,7 @@ for await (const msg of logMessages) {
 
     console.log(`${currentTime} [${subject}] ${logMessage}`);
     await Deno.writeFile(
-      "log.txt",
+      logFilePath,
       encoder.encode(`${currentTime} [${subject}] ${logMessage}\n`),
       { append: true },
     );

--- a/docs/docs/Backend Development/typescript/e2e-log-service.md
+++ b/docs/docs/Backend Development/typescript/e2e-log-service.md
@@ -16,6 +16,7 @@ This tutorial will explain step-by-step how to write a log service that will lis
 	```ts
 	import { startService } from "https://deno.land/x/telestion/mod.ts";
 	import { encode } from "https://deno.land/std@0.186.0/encoding/hex.ts";
+	import { resolve } from "https://deno.land/std@0.186.0/path/mod.ts";
 	```
 
 2. Next, we create a new TextEncoder instance. This will be used to turn messages into a format that can be written to a file.
@@ -27,16 +28,23 @@ This tutorial will explain step-by-step how to write a log service that will lis
 3. We then call the `startService` function to set up our service. This will return an object containing information about the message bus that we can use to subscribe to messages.
 
 	```ts
-	const { messageBus } = await startService();
+	const { messageBus, dataDir } = await startService();
 	```
 
-4. We then subscribe to the message bus, using a wildcard subscription for any messages published on the `log.>` subject. This will allow us to receive all messages published on any topics starting with `log.`.
+4. We then resolve the log file path and create its parent directory if it doesn't exist yet.
+
+	```ts
+	const logFilePath = resolve(dataDir, "log.txt");
+	await Deno.mkdir(dataDir, { recursive: true });
+	```
+
+5. We then subscribe to the message bus, using a wildcard subscription for any messages published on the `log.>` subject. This will allow us to receive all messages published on any topics starting with `log.`.
 
 	```ts
 	const logMessages = messageBus.subscribe("log.>");
 	```
 
-5. We use a for-await-of loop to receive messages from the message bus. For each message, we extract the subject (split the string on `.`, then take the second element) and the message data, which we encode using the `encode` function from the standard library.
+6. We use a for-await-of loop to receive messages from the message bus. For each message, we extract the subject (split the string on `.`, then take the second element) and the message data, which we encode using the `encode` function from the standard library.
 
 	```ts
 	for await (const msg of logMessages) {
@@ -46,12 +54,12 @@ This tutorial will explain step-by-step how to write a log service that will lis
 		const subject = msg.subject.split(".")[1];
 	```
 
-6. We log the message to the console and write it to a file (appending it to the end).
+7. We log the message to the console and write it to a file (appending it to the end).
 
 	```ts
 		console.log(`${currentTime} [${subject}] ${logMessage}`);
 		await Deno.writeFile(
-		  "log.txt",
+		  logFilePath,
 		  encoder.encode(`${currentTime} [${subject}] ${logMessage}\n`),
 		  { append: true },
 		);
@@ -68,10 +76,14 @@ And that's it! Our service is now complete and ready to be used.
 ```ts
 import { startService } from "https://deno.land/x/telestion/mod.ts";
 import { encode } from "https://deno.land/std@0.186.0/encoding/hex.ts";
+import { resolve } from "https://deno.land/std/0.186.0/path/mod.ts";
 
 const encoder = new TextEncoder();
 
-const { messageBus } = await startService();
+const { messageBus, dataDir } = await startService();
+
+const logFilePath = resolve(dataDir, "log.txt");
+await Deno.mkdir(dataDir, { recursive: true });
 
 const logMessages = messageBus.subscribe("log.>");
 
@@ -83,7 +95,7 @@ for await (const msg of logMessages) {
 
     console.log(`${currentTime} [${subject}] ${logMessage}`);
     await Deno.writeFile(
-      "log.txt",
+      logFilePath,
       encoder.encode(`${currentTime} [${subject}] ${logMessage}\n`),
       { append: true },
     );


### PR DESCRIPTION
Use the configurations data directory instead of the PWD to save the log messages.
