### PR TITLE
Document the Go module release system (prefixed tags)

### DIFF
--- a/backend-go/README.md
+++ b/backend-go/README.md
@@ -65,6 +65,14 @@ the [Behavior Specification](https://docs.telestion.wuespace.de/Backend%20Develo
 This specification is also used to test the library.
 The source code of the tests can be found in the repository under `/backend-features`.
 
+## Releasing a new version
+
+To release a new version of the Go library, a special tag has to be created next to the main release tag. For example, if the released version tag is `v1.0.0-alpha.0`, a second tag (prefixed with the subdirectory) has to be created: `backend-go/v1.0.0-alpha.0`. Otherwise, the Go package registry doesn't detect the new version.
+
+> If a module is defined in a subdirectory within the repository, that is, the module subdirectory portion of the module path is not empty, then each tag name must be prefixed with the module subdirectory, followed by a slash. For example, the module golang.org/x/tools/gopls is defined in the gopls subdirectory of the repository with root path golang.org/x/tools. The version v0.4.0 of that module must have the tag named gopls/v0.4.0 in that repository.
+
+-- https://go.dev/ref/mod#vcs-version
+
 ## License
 
 This project is licensed under the terms of the [MIT license](LICENSE).


### PR DESCRIPTION
Go modules defined in a subdirectory need release tags prefixed with the subdirectory name in order to be recognized [1].
Based on us storing our Go module in the `backend-go` subdirectory of the repo, we therefore need tags prefixed with `backend-go/[release-version]`.
For `v1.0.0-alpha.4` (due to caching problems), this was verified to work with the tag `backend-go/v1.0.0-goalpha.4`, which was found by pkg.go.dev [2].

This commit documents this knowledge (for now inside the Go package `README.md`), until a more formal release workflow documentation / automation gets established.

* [1] https://web.archive.org/web/20240127035037/https://go.dev/ref/mod#vcs-version
* [2] https://pkg.go.dev/github.com/wuespace/telestion/backend-go@v1.0.0-goalpha.4