### PR TITLE
Modernize Deno implementation and prepare for JSR

### DIFF
--- a/backend-deno/README.md
+++ b/backend-deno/README.md
@@ -8,7 +8,7 @@ This library provides a framework for building Telestion services in Deno.
 ## Usage
 
 ```typescript
-import {startService} from 'https://deno.land/x/telestion/mod.ts';
+import {startService} from 'jsr:@wuespace/telestion';
 
 const {nc} = await startService();
 ```

--- a/backend-deno/cucumber/deps.ts
+++ b/backend-deno/cucumber/deps.ts
@@ -1,3 +1,0 @@
-export * from "https://deno.land/std@0.209.0/assert/mod.ts";
-export * from "https://deno.land/std@0.209.0/path/mod.ts";
-export { parseArgs } from "https://deno.land/std@0.209.0/cli/parse_args.ts";

--- a/backend-deno/cucumber/step-registry.ts
+++ b/backend-deno/cucumber/step-registry.ts
@@ -1,4 +1,4 @@
-import { resolve } from "./deps.ts";
+import { resolve } from "@std/path";
 
 /**
  * A step definition

--- a/backend-deno/cucumber/steps/config.ts
+++ b/backend-deno/cucumber/steps/config.ts
@@ -1,6 +1,6 @@
-import { startService } from "../../mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
 import { Given, Then } from "../step-registry.ts";
-import { assertEquals } from "./deps.ts";
+import { assertEquals } from "@std/assert";
 
 Given('I have an environment variable named {string} with value {string}', (_ctx, key, value) => {
   Deno.env.set(key, value);

--- a/backend-deno/cucumber/steps/deps.ts
+++ b/backend-deno/cucumber/steps/deps.ts
@@ -1,5 +1,0 @@
-export * from "https://deno.land/std@0.209.0/assert/mod.ts"
-export type {
-  ConnectionOptions,
-  NatsConnection,
-} from "https://deno.land/x/nats@v1.13.0/nats-base-client/mod.ts";

--- a/backend-deno/cucumber/steps/nats.ts
+++ b/backend-deno/cucumber/steps/nats.ts
@@ -1,5 +1,6 @@
+import type { ConnectionOptions, NatsConnection } from "@nats-io/nats-core";
 import { Given, Then } from "../step-registry.ts";
-import { ConnectionOptions, NatsConnection, assert, assertEquals } from "./deps.ts";
+import { assert, assertEquals } from "@std/assert";
 
 /**
  * A mock NATS client that can be used to test services that use NATS.

--- a/backend-deno/cucumber/steps/start.ts
+++ b/backend-deno/cucumber/steps/start.ts
@@ -1,6 +1,6 @@
-import { startService } from "../../mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
 import { Then, When } from "../step-registry.ts";
-import { assert, assertRejects } from "./deps.ts";
+import { assert, assertRejects } from "@std/assert";
 
 When("I start the service", async (ctx) => {
   if (!ctx.nats) {

--- a/backend-deno/cucumber/test.ts
+++ b/backend-deno/cucumber/test.ts
@@ -13,8 +13,10 @@
   * MIT License (MIT)
   */
 
-import { AssertionError, parseArgs, resolve } from "./deps.ts";
+import { parseArgs } from "@std/cli";
 import { getStep, importStepDefinitions } from "./step-registry.ts";
+import { resolve } from "@std/path";
+import { AssertionError } from "@std/assert";
 
 /// Determine steps and features folder from command line arguments
 

--- a/backend-deno/deno.json
+++ b/backend-deno/deno.json
@@ -1,0 +1,23 @@
+{
+  "name": "@wuespace/telestion",
+  "license": "MIT",
+  "version": "1.0.0-alpha.4",
+  "exports": "./mod.ts",
+  "publish": {
+    "include": [
+      "mod.ts",
+      "README.md",
+      "LICENSE"
+    ]
+  },
+  "imports": {
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-45",
+    "@nats-io/transport-deno": "jsr:@nats-io/transport-deno@3.0.0-18",
+    "@std/assert": "jsr:@std/assert@^1.0.8",
+    "@std/cli": "jsr:@std/cli@^1.0.7",
+    "@std/jsonc": "jsr:@std/jsonc@^1.0.1",
+    "@std/path": "jsr:@std/path@^1.0.8",
+    "jsr:@wuespace/telestion": "./mod.ts",
+    "zod": "npm:zod@^3.23.8"
+  }
+}

--- a/backend-deno/deno.lock
+++ b/backend-deno/deno.lock
@@ -1,0 +1,117 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@nats-io/nats-core@3.0.0-45": "3.0.0-45",
+    "jsr:@nats-io/nats-core@~3.0.0-45": "3.0.0-45",
+    "jsr:@nats-io/nkeys@~2.0.0-2": "2.0.0-3",
+    "jsr:@nats-io/nuid@2.0.1-2": "2.0.1-2",
+    "jsr:@nats-io/transport-deno@3.0.0-18": "3.0.0-18",
+    "jsr:@std/assert@*": "1.0.8",
+    "jsr:@std/assert@^1.0.8": "1.0.8",
+    "jsr:@std/bytes@^1.0.2": "1.0.4",
+    "jsr:@std/cli@*": "1.0.7",
+    "jsr:@std/cli@^1.0.7": "1.0.7",
+    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/io@0.225.0": "0.225.0",
+    "jsr:@std/json@1": "1.0.1",
+    "jsr:@std/jsonc@*": "1.0.1",
+    "jsr:@std/jsonc@^1.0.1": "1.0.1",
+    "jsr:@std/path@*": "1.0.8",
+    "jsr:@std/path@^1.0.8": "1.0.8",
+    "npm:tweetnacl@1.0.3": "1.0.3",
+    "npm:zod@*": "3.23.8",
+    "npm:zod@^3.23.8": "3.23.8"
+  },
+  "jsr": {
+    "@nats-io/nats-core@3.0.0-45": {
+      "integrity": "a84bde6ccf1c2620cdff3d855f6823176859813e731c9257870309709b4bbd8a",
+      "dependencies": [
+        "jsr:@nats-io/nkeys",
+        "jsr:@nats-io/nuid"
+      ]
+    },
+    "@nats-io/nkeys@2.0.0-3": {
+      "integrity": "5f5eb02ebbd259d88e922392cb547157d16bb1e3283cebd2d18b23ce1d070fe8",
+      "dependencies": [
+        "npm:tweetnacl"
+      ]
+    },
+    "@nats-io/nuid@2.0.1-2": {
+      "integrity": "0cf115cfbc5e93c81464696e1c2cf3fdcd43d8aa23ba7446067d8e91029d39b8"
+    },
+    "@nats-io/transport-deno@3.0.0-18": {
+      "integrity": "b3b93b55d31ff34f501dc64f193b997ecd40acadbf654a2b12396b5e808227d6",
+      "dependencies": [
+        "jsr:@nats-io/nats-core@~3.0.0-45",
+        "jsr:@std/io"
+      ]
+    },
+    "@std/assert@1.0.8": {
+      "integrity": "ebe0bd7eb488ee39686f77003992f389a06c3da1bbd8022184804852b2fa641b",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/bytes@1.0.4": {
+      "integrity": "11a0debe522707c95c7b7ef89b478c13fb1583a7cfb9a85674cd2cc2e3a28abc"
+    },
+    "@std/cli@1.0.7": {
+      "integrity": "98359df9df586a69015ba570305183b0cb9e7d53c05ea2016ef9a3e77e82c7cd"
+    },
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/io@0.225.0": {
+      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/json@1.0.1": {
+      "integrity": "1f0f70737e8827f9acca086282e903677bc1bb0c8ffcd1f21bca60039563049f"
+    },
+    "@std/jsonc@1.0.1": {
+      "integrity": "6b36956e2a7cbb08ca5ad7fbec72e661e6217c202f348496ea88747636710dda",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    }
+  },
+  "npm": {
+    "tweetnacl@1.0.3": {
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "zod@3.23.8": {
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+    }
+  },
+  "remote": {
+    "https://deno.land/x/zod@v3.21.4/ZodError.ts": "4de18ff525e75a0315f2c12066b77b5c2ae18c7c15ef7df7e165d63536fdf2ea",
+    "https://deno.land/x/zod@v3.21.4/errors.ts": "5285922d2be9700cc0c70c95e4858952b07ae193aa0224be3cbd5cd5567eabef",
+    "https://deno.land/x/zod@v3.21.4/external.ts": "a6cfbd61e9e097d5f42f8a7ed6f92f93f51ff927d29c9fbaec04f03cbce130fe",
+    "https://deno.land/x/zod@v3.21.4/helpers/enumUtil.ts": "54efc393cc9860e687d8b81ff52e980def00fa67377ad0bf8b3104f8a5bf698c",
+    "https://deno.land/x/zod@v3.21.4/helpers/errorUtil.ts": "7a77328240be7b847af6de9189963bd9f79cab32bbc61502a9db4fe6683e2ea7",
+    "https://deno.land/x/zod@v3.21.4/helpers/parseUtil.ts": "51a76c126ee212be86013d53a9d07f87e9ae04bb1496f2558e61b62cb74a6aa8",
+    "https://deno.land/x/zod@v3.21.4/helpers/partialUtil.ts": "998c2fe79795257d4d1cf10361e74492f3b7d852f61057c7c08ac0a46488b7e7",
+    "https://deno.land/x/zod@v3.21.4/helpers/typeAliases.ts": "0fda31a063c6736fc3cf9090dd94865c811dfff4f3cb8707b932bf937c6f2c3e",
+    "https://deno.land/x/zod@v3.21.4/helpers/util.ts": "8baf19b19b2fca8424380367b90364b32503b6b71780269a6e3e67700bb02774",
+    "https://deno.land/x/zod@v3.21.4/index.ts": "d27aabd973613985574bc31f39e45cb5d856aa122ef094a9f38a463b8ef1a268",
+    "https://deno.land/x/zod@v3.21.4/locales/en.ts": "a7a25cd23563ccb5e0eed214d9b31846305ddbcdb9c5c8f508b108943366ab4c",
+    "https://deno.land/x/zod@v3.21.4/mod.ts": "64e55237cb4410e17d968cd08975566059f27638ebb0b86048031b987ba251c4",
+    "https://deno.land/x/zod@v3.21.4/types.ts": "b5d061babea250de14fc63764df5b3afa24f2b088a1d797fc060ba49a0ddff28"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@nats-io/nats-core@3.0.0-45",
+      "jsr:@nats-io/transport-deno@3.0.0-18",
+      "jsr:@std/assert@^1.0.8",
+      "jsr:@std/cli@^1.0.7",
+      "jsr:@std/jsonc@^1.0.1",
+      "jsr:@std/path@^1.0.8",
+      "npm:zod@^3.23.8"
+    ]
+  }
+}

--- a/backend-deno/docker-compose.yml
+++ b/backend-deno/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   backend-deno:
-    image: denoland/deno:1.39.0
-    command: [ "test", "--allow-all", "/app/cucumber/test.ts", "--",
+    image: denoland/deno:2.1.2
+    working_dir: /app
+    command: [ "test", "--allow-all", "./cucumber/test.ts", "--",
                "--features", "/features",
                "--steps", "/app/cucumber/steps", ]
     volumes:

--- a/backend-deno/mod.ts
+++ b/backend-deno/mod.ts
@@ -18,7 +18,7 @@ let natsModule = natsTransport;
  *
  * @see {@link startService}
  */
-interface StartServiceConfig {
+export interface StartServiceConfig {
   /**
    * Whether to enable NATS or not. Disabling NATS can be useful during development.
    * @default true

--- a/backend-deno/samples/CONTRIBUTING.md
+++ b/backend-deno/samples/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Most samples should also have a `mod.ts` file that contains the sample code.
 To import the Telestion library, use the following import statement:
 
 ```typescript
-import { startService } from "https://deno.land/x/telestion/mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
 ```
 
 This ensures that the import gets aliases to the repository's library files.

--- a/backend-deno/samples/Dockerfile
+++ b/backend-deno/samples/Dockerfile
@@ -1,11 +1,13 @@
-FROM denoland/deno:alpine-1.39.0
+FROM denoland/deno:alpine-2.1.2
 LABEL version="1.0.0-alpha.4" maintainer="WüSpace e. V. <telestion@wuespace.de>"
 
 # Add files
 COPY ./mod.ts /app/mod.ts
+COPY ./deno.json /app/deno.json
 COPY ./samples /app/samples
 
 # Cache dependencies in container layer
+WORKDIR /app
 RUN deno cache /app/samples/**/*.ts
 
 # Run

--- a/backend-deno/samples/config/mod.ts
+++ b/backend-deno/samples/config/mod.ts
@@ -1,8 +1,8 @@
-import {startService} from "jsr:@wuespace/telestion";
-import {z} from "npm:zod";
+import { startService } from "jsr:@wuespace/telestion";
+import { z } from "npm:zod";
 
 // Start the service
-const {config, serviceName, dataDir} = await startService({
+const { config, serviceName, dataDir } = await startService({
     nats: false // we don't need NATS to work with the config
 });
 

--- a/backend-deno/samples/config/mod.ts
+++ b/backend-deno/samples/config/mod.ts
@@ -1,5 +1,5 @@
-import {startService} from "https://deno.land/x/telestion/mod.ts";
-import {z} from "https://deno.land/x/zod@v3.21.4/mod.ts";
+import {startService} from "jsr:@wuespace/telestion";
+import {z} from "npm:zod";
 
 // Start the service
 const {config, serviceName, dataDir} = await startService({

--- a/backend-deno/samples/deno.jsonc
+++ b/backend-deno/samples/deno.jsonc
@@ -1,5 +1,0 @@
-{
-	"imports": {
-		"https://deno.land/x/telestion/mod.ts": "../mod.ts"
-	}
-}

--- a/backend-deno/samples/latest-value-cache/mod.ts
+++ b/backend-deno/samples/latest-value-cache/mod.ts
@@ -1,5 +1,5 @@
-import { startService } from "https://deno.land/x/telestion/mod.ts";
-import { z } from "https://deno.land/x/zod@v3.21.4/mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
+import { z } from "npm:zod";
 
 const { messageBus, config, serviceName } = await startService();
 

--- a/backend-deno/samples/logger/mod.ts
+++ b/backend-deno/samples/logger/mod.ts
@@ -1,6 +1,6 @@
-import { startService } from "https://deno.land/x/telestion/mod.ts";
-import { encode } from "https://deno.land/std@0.186.0/encoding/hex.ts";
-import { resolve } from "https://deno.land/std@0.186.0/path/mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
+import { encodeHex } from "jsr:@std/encoding/hex";
+import { resolve } from "jsr:@std/path";
 
 const encoder = new TextEncoder();
 
@@ -16,7 +16,7 @@ console.log("Logger started");
 for await (const msg of logMessages) {
   try {
     const currentTime = new Date().toISOString();
-    const logMessage = encode(msg.data).toString();
+    const logMessage = encodeHex(msg.data).toString();
     const subject = msg.subject.split(".")[1];
 
     console.log(`${currentTime} [${subject}] ${logMessage}`);

--- a/backend-deno/samples/publisher/mod.ts
+++ b/backend-deno/samples/publisher/mod.ts
@@ -1,4 +1,4 @@
-import { JSONCodec, startService } from "jsr:@wuespace/telestion";
+import { startService } from "jsr:@wuespace/telestion";
 import { z } from "npm:zod";
 
 const { messageBus, config } = await startService();
@@ -20,7 +20,7 @@ setInterval(() => {
   console.log("Publishing", value, "to", DATA_SUBJECT);
   messageBus.publish(
     DATA_SUBJECT,
-    JSONCodec().encode(value),
+    JSON.stringify(value),
   );
   console.log("Published", value, "to", DATA_SUBJECT);
 }, FREQUENCY);

--- a/backend-deno/samples/publisher/mod.ts
+++ b/backend-deno/samples/publisher/mod.ts
@@ -1,5 +1,5 @@
-import { JSONCodec, startService } from "https://deno.land/x/telestion/mod.ts";
-import { z } from "https://deno.land/x/zod@v3.21.4/mod.ts";
+import { JSONCodec, startService } from "jsr:@wuespace/telestion";
+import { z } from "npm:zod";
 
 const { messageBus, config } = await startService();
 

--- a/backend-deno/samples/requester/mod.ts
+++ b/backend-deno/samples/requester/mod.ts
@@ -1,5 +1,5 @@
-import { startService } from "https://deno.land/x/telestion/mod.ts";
-import { z } from "https://deno.land/x/zod@v3.21.4/mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
+import { z } from "npm:zod";
 
 const { messageBus, config } = await startService();
 

--- a/docs/docs/Backend Development/typescript/configuration.md
+++ b/docs/docs/Backend Development/typescript/configuration.md
@@ -115,7 +115,7 @@ Create a file called `config.json` next to your `service.ts` file with the follo
 Now, let's adjust the `service.ts` file to use the configuration:
 
 ```typescript title="service.ts"
-import { startService } from "https://deno.land/x/telestion/mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
 import { z } from "https://deno.land/x/zod@v3.21.4/mod.ts";// (1)!
 
 const { config: rawConfig/* (2)! */} = await startService({

--- a/docs/docs/Backend Development/typescript/e2e-log-service.md
+++ b/docs/docs/Backend Development/typescript/e2e-log-service.md
@@ -11,12 +11,12 @@ This tutorial will explain step-by-step how to write a log service that will lis
 
 ## Steps
 
-1. First, we need to import the `startService` function from our library (`lib.ts`) and the `encode` function from the standard Deno library.
+1. First, we need to import the `startService` function from our library (`lib.ts`) and the `encodeHex` function from the standard Deno library.
 
 	```ts
-	import { startService } from "https://deno.land/x/telestion/mod.ts";
-	import { encode } from "https://deno.land/std@0.186.0/encoding/hex.ts";
-	import { resolve } from "https://deno.land/std@0.186.0/path/mod.ts";
+	import { startService } from "jsr:@wuespace/telestion";
+	import { encodeHex } from "jsr:@std/encoding";
+	import { resolve } from "jsr:@std/path";
 	```
 
 2. Next, we create a new TextEncoder instance. This will be used to turn messages into a format that can be written to a file.
@@ -44,13 +44,13 @@ This tutorial will explain step-by-step how to write a log service that will lis
 	const logMessages = messageBus.subscribe("log.>");
 	```
 
-6. We use a for-await-of loop to receive messages from the message bus. For each message, we extract the subject (split the string on `.`, then take the second element) and the message data, which we encode using the `encode` function from the standard library.
+6. We use a for-await-of loop to receive messages from the message bus. For each message, we extract the subject (split the string on `.`, then take the second element) and the message data, which we encode using the `encodeHex` function from the standard library.
 
 	```ts
 	for await (const msg of logMessages) {
 	  try {
 		const currentTime = new Date().toISOString();
-		const logMessage = encode(msg.data).toString();
+		const logMessage = encodeHex(msg.data).toString();
 		const subject = msg.subject.split(".")[1];
 	```
 
@@ -74,9 +74,9 @@ And that's it! Our service is now complete and ready to be used.
 ## Final Code
 
 ```ts
-import { startService } from "https://deno.land/x/telestion/mod.ts";
-import { encode } from "https://deno.land/std@0.186.0/encoding/hex.ts";
-import { resolve } from "https://deno.land/std/0.186.0/path/mod.ts";
+import { startService } from "jsr:@wuespace/telestion";
+import { encodeHex } from "jsr:@std/encoding";
+import { resolve } from "jsr:@std/path";
 
 const encoder = new TextEncoder();
 
@@ -90,7 +90,7 @@ const logMessages = messageBus.subscribe("log.>");
 for await (const msg of logMessages) {
   try {
     const currentTime = new Date().toISOString();
-    const logMessage = encode(msg.data).toString();
+    const logMessage = encodeHex(msg.data).toString();
     const subject = msg.subject.split(".")[1];
 
     console.log(`${currentTime} [${subject}] ${logMessage}`);

--- a/docs/docs/Backend Development/typescript/index.md
+++ b/docs/docs/Backend Development/typescript/index.md
@@ -48,7 +48,7 @@ touch service.ts
 Open `service.ts` in your favorite editor and add the following code:
 
 ```typescript title="service.ts"
-import { startService } from 'https://deno.land/x/telestion/mod.ts';// (1)!
+import { startService } from 'jsr:@wuespace/telestion';// (1)!
 
 await startService/*(2)!*/({
 	nats: false,// (3)!

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -23,7 +23,7 @@ This documentation is about developing a Ground Station software using Telestion
 
 * [NATS](https://nats.io/) -- The message bus used by Telestion
 * [TypeScript](https://www.typescriptlang.org/) -- The programming language used for most components by Telestion
-* [Deno](https://deno.land/) -- The runtime used by Telestion for TypeScript and JavaScript based services
+* [Deno](https://deno.com/) -- The runtime used by Telestion for TypeScript and JavaScript based services
 * [React](https://reactjs.org/) -- The frontend framework used by Telestion
 
 ## Discord


### PR DESCRIPTION
Updates everything to be compatible with Deno v2 and prepares for
publishing the packages to the [JSR](https://jsr.io) instead of
the HTTPS based imports common before the JSR.

The JSR doesn't allow for complex inferred types.[^1]
Therefore, prior `z.infer<Schema>` types have been replaced with
explicit interfaces.

Instead of the pattern of having all dependencies defined in a `deps.ts`,
it is now common practice (and requirement for the JSR) to have a `deno.json`,
which acts in a similar way to the `package.json` in NodeJS. It also serves
as an import map for dependencies, pinning their versions.

Note that while it's possible to omit the `jsr:@scope/package` and just write
`@scope/package` with this, to keep samples copy-pasteable without having to
copy the import map, imports in the samples still use the "fully qualified"
import, even though the respective versions are then pinned down using the
`deno.json` file.

In the `Dockerfile`s for the samples as well as the `docker-compose.yml` for
development in the root `backend-deno` folder, the Deno base image was upgraded
to Deno v2.

The new NATS version doesn't use (or provide) the codec functions anymore.[^2]
Therefore, the version upgrade also means that we no longer provide these as
re-exported functions.

Now, any publishing method also allows to pass a `string`, meaning one can just
use something like:

```ts
nc.publish(JSON.stringify({}));
```

Also, the `Msg` interface (any message received by NATS) now offers convenience
methods for retrieving the payload as either `json()` or a `string()`.

- JetStream is no longer included and has to be installed as `jsr:@nats-io/jetstream`;
- KV (a key-value-storage) is no longer included, but available as `jsr:@nats-io/kv`.

See <https://github.com/nats-io/nats.js/blob/e8520523a9b5316f436c44ef05ba2e50c4f6e60a/migration.md>
for a full list of changes / migration guide.

In `ensureMinimalConfig()` (which gets called by `startService()`), the function
now throws an error instead of just printing it to the console and running
`Deno.exit(1)`. This fixes various tests that failed with the upgraded Deno version.

Note that I was unable to find the change that introduced the inabilities of tests to
handle `Deno.exit(1)`. I just know that it worked previously, didn't anymore, and will
now, with this change, work once again.

[^1]: Cf. <https://jsr.io/docs/about-slow-types>
[^2]: Cf. <https://github.com/nats-io/nats.js/blob/e8520523a9b5316f436c44ef05ba2e50c4f6e60a/migration.md#changes-in-nats-base-client>

### Summary <!-- Summarize the content of the pull request in one sentence -->

n/a

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

- Fixes # .

### CLA

- [ ] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
