### PR TITLE
feat(frontend-react): Improve UI design of page wrapper

### DIFF
--- a/frontend-react/src/lib/application/routes/page-wrapper/page-wrapper.module.css
+++ b/frontend-react/src/lib/application/routes/page-wrapper/page-wrapper.module.css
@@ -9,7 +9,7 @@ if it got applied immediately on the body while being in a visible wrapper / wid
 }
 
 [data-bs-theme='dark'] .pageBackground {
-	background-color: black;
+	background-color: #111;
 }
 
 /*Layout, etc.*/

--- a/frontend-react/src/lib/application/routes/page-wrapper/page-wrapper.tsx
+++ b/frontend-react/src/lib/application/routes/page-wrapper/page-wrapper.tsx
@@ -65,12 +65,17 @@ export function PageWrapper({ showSelector }: PageWrapperProps) {
 							<DashboardDropdown dashboards={dashboards} />
 							{dashboardId &&
 								(match ? (
-									<Button size="sm" form="dashboard-editor" type="submit">
+									<Button
+										size="sm"
+										form="dashboard-editor"
+										type="submit"
+										className="ms-2"
+									>
 										Save
 									</Button>
 								) : (
 									<Link
-										className="btn btn-sm btn-secondary"
+										className="btn btn-sm btn-secondary ms-2"
 										to={generatePath('/dashboards/:dashboardId/edit', {
 											dashboardId
 										})}


### PR DESCRIPTION
Make the background color in dark mode a less absolute black, and add a bit of margin between the dashboard dropdown and the buttons.

<!-- branch-stack -->

- `main`
  - \#424
    - \#426 :point\_left:
