### PR TITLE
chore(ci): Add Git Town Workflow for Stacked PRs

### DIFF
--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -1,0 +1,20 @@
+name: Git Town
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  git-town:
+    name: Display the branch stack
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: git-town/action@v1
+


### PR DESCRIPTION
Adds an action that shows an overview of PR stacks inside GitHub PRs.

<!-- branch-stack -->

- `main`
  - \#427 :point\_left:
