### PR TITLE
Add configuration for automated GitHub Release Changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 💥
+      labels:
+        - ":boom: breaking"
+    - title: Exciting New Features 🎉
+      labels:
+        - ":tulip: enhancement"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Cf. <https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes> for details on the format.
