### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -100,9 +100,13 @@ jobs:
     steps:
       - name: Checkout 📥
         uses: actions/checkout@v3.6.0
+        # set GitHub Actions Bot as git user
+        # see: https://github.com/actions/checkout/pull/1707
       - name: Create Go Version Tag
         run: |
           tag=${GITHUB_REF#refs/tags/}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "backend-go/$tag" -m "Go Release $tag"
           git push origin "backend-go/$tag"
   ######################

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -154,6 +154,7 @@ jobs:
           node-version: ${{ env.node }}
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies 📚
         run: pnpm install
       - name: Build 🏗️

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,13 @@ jobs:
     steps:
       - name: Checkout 📥
         uses: actions/checkout@v3.6.0
+        # set GitHub Actions Bot as git user
+        # see: https://github.com/actions/checkout/pull/1707
       - name: Create Go Version Tag
         run: |
           tag=${GITHUB_REF#refs/tags/}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "backend-go/$tag" -m "Go Release $tag"
           git push origin "backend-go/$tag"
   ######################

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
           node-version: ${{ env.node }}
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies 📚
         run: pnpm install
       - name: Build 🏗️


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

This PR tries to fix the release pipelines for prereleases and releases.

It adds a proper git user to allow the backend-go job tagging and pushing of the required go tag.
(see <https://github.com/wuespace/telestion/tree/main/backend-go#releasing-a-new-version>)

Additionally, it sets the npm registry in the frontend-react job to hopefully convince npm to use the `NODE_AUTH_TOKEN`. :see\_no\_evil:

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

- Fixes # .

### CLA

- [ ] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.

<!-- branch-stack -->

- `main`
  - \#433 :point\_left:
