### PR TITLE
fix(frontend-react): TELESTION-479 Everything breaks if no widgets ar…

### DIFF
--- a/frontend-react/src/lib/application/routes/dashboard-editor/dashboard-editor.tsx
+++ b/frontend-react/src/lib/application/routes/dashboard-editor/dashboard-editor.tsx
@@ -67,6 +67,9 @@ export function DashboardEditor() {
 	const onLayoutEditorCreateWidgetInstance = useCallback(() => {
 		const newId = generateDashboardId();
 		const widgetTypes = getWidgets();
+		if (widgetTypes.length === 0) {
+			throw new Error('No registered widget types found. Code: 9ca3dd78');
+		}
 		const widgetType = widgetTypes[0];
 
 		const configuration = widgetType.createConfig({});
@@ -262,6 +265,7 @@ function useDashboardEditorData() {
 		const { dashboardId, dashboard, widgetInstances } =
 			loaderSchema.parse(loaderData);
 
+		// eslint-disable-next-line react-hooks/set-state-in-effect
 		setLocalDashboard({
 			selection: {
 				x: 0,

--- a/frontend-react/src/lib/application/routes/dashboard-editor/layout-editor/components/layout-editor.tsx
+++ b/frontend-react/src/lib/application/routes/dashboard-editor/layout-editor/components/layout-editor.tsx
@@ -122,8 +122,16 @@ export function LayoutEditor(props: LayoutEditorProps) {
 					return state;
 				}
 
-				const widgetId = props.onCreateWidgetInstance();
-				return select(fillWith(state, widgetId, bounds), bounds);
+				try {
+					const widgetId = props.onCreateWidgetInstance();
+					return select(fillWith(state, widgetId, bounds), bounds);
+				} catch (err) {
+					console.error('Could not create widget instance.', {
+						code: 'e732b33a',
+						cause: err
+					});
+					return state;
+				}
 			});
 		},
 		[applyLayoutChange, props]


### PR DESCRIPTION
…e registered

Previously, when no widgets were regsitered, the application would break when trying to create the first dashboard.

This is now no longer the case.

- `main` <!-- branch-stack -->
  - \#434 :point\_left:
    - \#436
