### PR TITLE
Activate footnotes on the documentation site

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,6 +80,7 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - footnotes
 
 plugins:
   - awesome-pages


### PR DESCRIPTION
This is primarily necessary for the migration of the ADRs. However, it's also nice to have the ability to have footnotes for references and the like. Therefore, it is useful to add footnotes, which can be achieved using the `footnotes` markdown extension.

M. Donath, “Footnotes - material for MKDocs.” <https://squidfunk.github.io/mkdocs-material/reference/footnotes/>

- `main` <!-- branch-stack -->
  - \#443 :point\_left:
    - \#442
